### PR TITLE
Change Readme Instructions for Development Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Require Laravel DB Auditor  using [Composer](https://getcomposer.org):
 
 ```bash
-composer require vcian/laravel-db-auditor
+composer require vcian/laravel-db-auditor -dev
 ```
 ## Usage:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Require Laravel DB Auditor  using [Composer](https://getcomposer.org):
 
 ```bash
-composer require vcian/laravel-db-auditor -dev
+composer require --dev vcian/laravel-db-auditor
 ```
 ## Usage:
 


### PR DESCRIPTION
This is a package used in development (not production?) so should have the --dev tag so its installed only in development environment.