### PR TITLE
Make references nullable

### DIFF
--- a/src/Traits/Audit.php
+++ b/src/Traits/Audit.php
@@ -93,8 +93,8 @@ trait Audit
         string $table,
         string $field,
         string $constraint,
-        string $referenceTableName = null,
-        string $referenceField = null
+        ?string $referenceTableName = null,
+        ?string $referenceField = null
     ): bool
     {
         try {


### PR DESCRIPTION
The following PR fixes the issue mentioned below:

**local.WARNING: Vcian\LaravelDBAuditor\Traits\Rules::checkRules(): Implicitly marking parameter $type as nullable is deprecated, the explicit nullable type must be used instead in /vendor/vcian/laravel-db-auditor/src/Traits/Rules.php on line 70**